### PR TITLE
Specify class name when inheriting lapis.Application

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ $markdown{[[
 ```moon
 lapis = require "lapis"
 
-class extends lapis.Application
+class MyApp extends lapis.Application
   "/": =>
     "Hello world!"
 ```


### PR DESCRIPTION
the example was missing a class name