### PR TITLE
Fix the outdated benchmarks link

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@ $markdown{[[
 Lua is run directly inside of the Nginx worker, giving you the smallest barrier
 between the webserver and your code. OpenResty executes your Lua/MoonScript
 with LuaJIT, so it's blazing fast. Have a look at [Web Framework
-Benchmarks](http://www.techempower.com/benchmarks/#section=data-r3) just to see
+Benchmarks](http://www.techempower.com/benchmarks) just to see
 how OpenResty stacks up against other platforms.
 
 Nginx's event loop is used for all asynchronous actions, including HTTP


### PR DESCRIPTION
The existing link points to "No data available for this test." message.
Something must have changed in https://www.techempower.com routing.